### PR TITLE
Add camera foreground service

### DIFF
--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -1,0 +1,13 @@
+# Manual Testing Steps
+
+To verify that recording continues when the camera activity is closed under memory pressure:
+
+1. Build and install the sample app.
+2. Launch `TruvideoSdkCameraActivity` and start a video recording.
+3. While recording, trigger an activity destruction:
+   - Enable **Developer Options > Don't keep activities** and switch away from the app, or
+   - Use the recent-apps screen to dismiss the activity.
+4. Wait a few seconds and reopen the app.
+5. Observe that the recording is still in progress and the preview is restored.
+
+This confirms that `CameraForegroundService` keeps the recording alive even if the activity is destroyed.

--- a/camera/src/main/AndroidManifest.xml
+++ b/camera/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application>
         <meta-data
@@ -60,6 +61,11 @@
                 android:name="com.truvideo.sdk.camera.TruvideoSdkCameraInitializer"
                 android:value="androidx.startup" />
         </provider>
+
+        <service
+            android:name=".service.camera.CameraForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="camera" />
     </application>
 
 </manifest>

--- a/camera/src/main/java/com/truvideo/sdk/camera/service/camera/CameraForegroundService.kt
+++ b/camera/src/main/java/com/truvideo/sdk/camera/service/camera/CameraForegroundService.kt
@@ -1,0 +1,69 @@
+package com.truvideo.sdk.camera.service.camera
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Binder
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.truvideo.sdk.camera.R
+
+/**
+ * Foreground service used to host [TruvideoSdkCameraService] so that recording
+ * can continue even when the associated activity is destroyed under memory
+ * pressure.
+ */
+class CameraForegroundService : Service() {
+
+    private val binder = LocalBinder()
+    var cameraService: TruvideoSdkCameraService? = null
+        private set
+
+    inner class LocalBinder : Binder() {
+        fun getService(): CameraForegroundService = this@CameraForegroundService
+    }
+
+    override fun onBind(intent: Intent?): IBinder = binder
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForegroundService()
+        return START_STICKY
+    }
+
+    fun initialize(service: TruvideoSdkCameraService) {
+        cameraService = service
+    }
+
+    override fun onDestroy() {
+        Log.d(TAG, "CameraForegroundService destroyed")
+        super.onDestroy()
+    }
+
+    private fun startForegroundService() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_ID,
+                NotificationManager.IMPORTANCE_LOW
+            )
+            val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(channel)
+            val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle(getString(R.string.truvideo_sdk_camera_service_name))
+                .setSmallIcon(android.R.drawable.ic_menu_camera)
+                .build()
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    companion object {
+        const val TAG = "CameraForegroundService"
+        private const val CHANNEL_ID = "truvideo_camera"
+        private const val NOTIFICATION_ID = 1
+    }
+}

--- a/camera/src/main/java/com/truvideo/sdk/camera/service/camera/TruvideoSdkCameraService.kt
+++ b/camera/src/main/java/com/truvideo/sdk/camera/service/camera/TruvideoSdkCameraService.kt
@@ -57,8 +57,8 @@ import java.util.Locale
 internal class TruvideoSdkCameraService(
     private val context: Context,
     val information: TruvideoSdkCameraInformation,
-    private val textureView: TextureView,
-    private val serviceCallback: TruvideoSdkCameraServiceCallback
+    private var textureView: TextureView,
+    private var serviceCallback: TruvideoSdkCameraServiceCallback
 ) {
 
     companion object {
@@ -98,6 +98,14 @@ internal class TruvideoSdkCameraService(
     private var videoOrientation = TruvideoSdkCameraOrientation.PORTRAIT
     private var videoLensFacing = TruvideoSdkCameraLensFacing.FRONT
 
+    fun updateTextureView(value: TextureView) {
+        textureView = value
+    }
+
+    fun updateServiceCallback(value: TruvideoSdkCameraServiceCallback) {
+        serviceCallback = value
+    }
+
     private var backgroundHandlerThread: HandlerThread? = null
     private var backgroundHandler: Handler? = null
 
@@ -117,6 +125,10 @@ internal class TruvideoSdkCameraService(
     private var maxDurationReported = false
     private var videoDurationTimer: PausableTimer? = null
     var videoDuration = MutableStateFlow(0L)
+
+    fun isRecording() = isRecording
+
+    fun isPaused() = isPaused
 
     val tapToFocusListener = object : GestureDetector.SimpleOnGestureListener() {
         override fun onSingleTapUp(event: MotionEvent): Boolean {

--- a/camera/src/main/res/values/strings.xml
+++ b/camera/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name_camera">TruVideoSDK-Camera</string>
     <string name="title_activity_camera_compose">CameraActivityCompose</string>
     <string name="title_activity_scanner">ScannerActivity</string>
+    <string name="truvideo_sdk_camera_service_name">Camera service</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `CameraForegroundService` to keep `TruvideoSdkCameraService` alive
- expose state and update callbacks in `TruvideoSdkCameraService`
- bind the activity to the foreground service and keep recording when paused
- register the foreground service in the manifest and add required permission
- document manual testing steps

## Testing
- `./gradlew test` *(fails: No route to host)*